### PR TITLE
Add conversation persistence with Supabase

### DIFF
--- a/app/chat/layout.tsx
+++ b/app/chat/layout.tsx
@@ -1,0 +1,15 @@
+import Sidebar from "@/components/navbar/Sidebar";
+import Topbar from "@/components/navbar/Topbar";
+import type { ReactNode } from "react";
+
+export default function ChatLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar />
+      <div className="flex-1 flex flex-col">
+        <Topbar />
+        <main className="flex-1 bg-[#fafafa] p-6 overflow-y-auto">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/utils/supabase/messages.ts
+++ b/app/utils/supabase/messages.ts
@@ -1,5 +1,12 @@
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 
+export type MessageRecord = {
+  id: string;
+  conversation_id: string;
+  role: "user" | "assistant";
+  content: string;
+};
+
 export async function saveMessage({
   conversation_id,
   role,
@@ -19,4 +26,16 @@ export async function saveMessage({
   ]);
 
   if (error) throw error;
+}
+
+export async function fetchMessages(conversationId: string): Promise<MessageRecord[]> {
+  const supabase = createClientComponentClient();
+  const { data, error } = await supabase
+    .from("messages")
+    .select("*")
+    .eq("conversation_id", conversationId)
+    .order("created_at", { ascending: true });
+
+  if (error) throw error;
+  return data;
 }

--- a/components/navbar/Sidebar.tsx
+++ b/components/navbar/Sidebar.tsx
@@ -14,12 +14,10 @@ type Conversation = {
 export default function Sidebar() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
 
-  useEffect(() => {
-    const loadConvos = async () => {
+  const loadConvos = async () => {
       const supabase = createClientComponentClient();
       const {
         data: { user },
-        error,
       } = await supabase.auth.getUser();
 
       console.log("👤 user:", user);
@@ -34,9 +32,13 @@ export default function Sidebar() {
       } catch (err) {
         console.error("❌ Failed to fetch conversations:", err);
       }
-    };
+  };
 
+  useEffect(() => {
     loadConvos();
+    const handler = () => loadConvos();
+    window.addEventListener("refresh-convos", handler);
+    return () => window.removeEventListener("refresh-convos", handler);
   }, []);
   
   


### PR DESCRIPTION
## Summary
- load and refresh conversation list in sidebar
- store chat messages and create conversations in Dashboard
- add typed utilities for reading messages
- add chat pages for existing conversations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b321b5f308323829bc0fafeb02de2