### PR TITLE
Fix message type for setMessages

### DIFF
--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -42,7 +42,10 @@ export default function ChatPage() {
   const sendMessage = async () => {
     if (!input.trim()) return;
     const userContent = input;
-    const newMessages = [...messages, { role: "user", content: userContent }];
+    const newMessages: { role: "user" | "assistant"; content: string }[] = [
+      ...messages,
+      { role: "user", content: userContent },
+    ];
     setMessages(newMessages);
     setInput("");
 


### PR DESCRIPTION
## Summary
- fix type of `newMessages` in chat page to maintain `'user' | 'assistant'` role union

## Testing
- `npm run lint`
- `npx tsc --noEmit --skipLibCheck`


------
https://chatgpt.com/codex/tasks/task_e_688b3507b8b48323a393d90e633b438f